### PR TITLE
jit: Phase 3h — forward reference の緩和（block + top-level）

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -59,11 +59,12 @@ AST → Cranelift IR 直行で native コード生成。tree-walker は referenc
 3e. ✅ stdlib 連携：List/String/Number 全 26 関数 — done 2026-05-03
 3f. ✅ `&&` / `||` 短絡、null、ImmediateBlock、任意戻り値 display（B path） — done 2026-05-03
 3g. ✅ list の構造比較（`emit_value_eq` で要素型を辿る再帰 lower）、record/closure 比較は tree-walker と同じく常に false に固定。record-by-string indexing はリテラル限定で parser desugar 経由で既に動作することを確認しテストで固定 — done 2026-05-17
-3h. （未着手）import、Block 内 forward reference 緩和、function 内で後の top-level value への forward reference、性能 polishing
-4. NaN-boxing にスイッチ（必要になったら）— Path A への切り替え選択肢として残す。null と他型の union、record の動的 string indexing（フィールド型異種の場合）はここで初めて意味を持つ
+3h. ✅ 前方参照の緩和。top-level Phase B を「Value 評価 → Function captures populate」の2 段に分け、function→later-value forward ref が動くように。block も同等の Phase 1/2/3 構造（function literal は Phase 1 で alloc + sibling cap を deferred、Phase 2 で value を source order に評価 + deferred cap を機会的に populate、Phase 3 で残り cap = 真サイクルを reject）。`BlockFrame.populated` を `Vec<bool>` に変更。これで block 内 mutual recursion と function→later-value forward ref が動く。value→value forward ref と「value が後方 value を capture する関数を呼ぶ」ケースは silent-wrong だったのを compile-time error に格上げ — done 2026-05-17
+3i. （未着手）import、性能 polishing
+4. NaN-boxing にスイッチ（必要になったら）— Path A への切り替え選択肢として残す。null と他型の union、record の動的 string indexing（フィールド型異種の場合）、value→value forward ref、value-calls-function-with-later-cap はここで初めて意味を持つ
 
-**Phase 3g までできること**：上記すべて + list の構造比較（`[1,2] == [1,2]` が JIT で `true`）。record-by-string indexing は文字列**リテラル**であれば `r.x` と等価に動く（parser が `Access` に desugar するため）。  
-**Phase 3g でできないこと**：import、Block 内 forward reference、function 内で後の top-level value への forward reference、record の動的 string indexing（`r[k]` で `k` が変数）、null と他型の union。最後の 2 つは値タグ（Phase 4 NaN-boxing）を待つ。
+**Phase 3h までできること**：上記すべて + top-level/block での **function→later-value forward ref**（`add_n: (x) => x + n, n: 10, add_n(5)` が 15 を返す）、**block 内 mutual recursion**（`is_even` / `is_odd` が動く）。value→value forward ref と value-calls-function-with-later-cap は明示的なエラーで reject。  
+**Phase 3h でできないこと**：import、value→value forward ref、value-calls-function-with-later-cap（後ろ 2 つは値タグ前提の Phase 4 で対応）。
 
 **Closure layout**: `[fn_ptr: 8][n_caps: 4][_pad: 4][cap_slot_0: 8][cap_slot_1: 8]...`。`spctr_alloc_closure(fn_ptr, n_caps)` でヒープから確保（leak）。すべての関数は `(closure_ptr: i64, args...) -> ret` の ABI。  
 **Record layout**: `[slot_0: 8][slot_1: 8]...`。`spctr_alloc_record(n_slots)` で確保。field offset = `8 * field_index`、field type は `Type::Record` の宣言順。  

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -1394,96 +1394,171 @@ impl Compiler {
             }
         }
 
-        // Phase B: in source order, populate function captures or evaluate
-        // value bindings. Iterating in source order guarantees that:
-        // - Values reference only earlier-defined top-level CVars (function
-        //   CVars are pre-allocated, earlier value CVars are populated by
-        //   prior iterations).
-        // - Function captures targeting a value are resolved against an
-        //   already-defined CVar.
+        // Phase B: two-phase to allow function→later-value forward references.
+        //   B1: evaluate Value bindings in source order, def_var their CVars.
+        //   B2: populate Function captures (all values are now def_var'd, so
+        //       any capture target — Function or Value — resolves cleanly).
+        //
+        // A value body that calls a sibling function whose captures point to
+        // a later value would silently read garbage in this order, so we
+        // detect that pattern up-front and reject it with a clear diagnostic.
         let mut order: Vec<usize> = (0..self.top_level_instances.len()).collect();
         order.sort_by_key(|&i| self.top_level_instances[i].slot);
-        for i in order {
+
+        // Pre-compute, per top-level slot, whether that slot's binding is a
+        // function and, if so, whether any of its captures point to a Value
+        // at a later source-order slot. Used by the forward-ref check below.
+        let n_inst = self.top_level_instances.len();
+        let mut func_caps_value_max_slot: Vec<Option<u32>> = vec![None; n_inst];
+        for (i, inst) in self.top_level_instances.iter().enumerate() {
+            if !matches!(inst.kind, TopKind::Function) {
+                continue;
+            }
+            let key: FuncKey = (inst.expr_ptr, inst.mono_ty_str.clone());
+            let info = self.funcs.get(&key).expect("declared").clone();
+            let mut max_value_target: Option<u32> = None;
+            for cap in &info.captures {
+                if cap.inside.depth != 1 {
+                    continue;
+                }
+                let target_kind = self
+                    .top_level_instances
+                    .iter()
+                    .find(|t| t.slot == cap.inside.slot && t.mono_ty_str == cap.mono_ty_str)
+                    .map(|t| t.kind.clone());
+                if matches!(target_kind, Some(TopKind::Value(_))) {
+                    max_value_target = Some(match max_value_target {
+                        Some(prev) => prev.max(cap.inside.slot),
+                        None => cap.inside.slot,
+                    });
+                }
+            }
+            func_caps_value_max_slot[i] = max_value_target;
+        }
+
+        // Per-slot kind lookup for forward-ref checks below.
+        let slot_top_idx: HashMap<u32, usize> = self
+            .top_level_instances
+            .iter()
+            .enumerate()
+            .map(|(i, t)| (t.slot, i))
+            .collect();
+
+        // B1: evaluate Value bindings.
+        for &i in &order {
             let inst = self.top_level_instances[i].clone();
-            match &inst.kind {
-                TopKind::Function => {
-                    let key: FuncKey = (inst.expr_ptr, inst.mono_ty_str.clone());
-                    let info = self.funcs.get(&key).expect("declared").clone();
-                    let closure_ptr = bcx.use_var(top_vars[i]);
-                    for (cap_idx, cap) in info.captures.iter().enumerate() {
-                        if cap.inside.depth != 1 {
-                            return Err(Diagnostic::new(
-                                body_span(ast, inst.expr_ptr),
-                                "JIT: top-level function references root scope",
-                                "Phase 3 rejects List/String/Number/import",
-                            ));
-                        }
-                        let target_idx = self
-                            .top_level_instances
-                            .iter()
-                            .position(|t| {
-                                t.slot == cap.inside.slot && t.mono_ty_str == cap.mono_ty_str
-                            })
-                            .ok_or_else(|| {
-                                internal(format!(
-                                    "missing top-level instance for capture (slot {}, ty {})",
-                                    cap.inside.slot, cap.mono_ty_str
-                                ))
-                            })?;
-                        // Forward reference to a Value not yet defined.
-                        let target = &self.top_level_instances[target_idx];
-                        if matches!(target.kind, TopKind::Value(_))
-                            && target.slot >= inst.slot
-                        {
-                            return Err(Diagnostic::new(
-                                body_span(ast, inst.expr_ptr),
-                                format!(
-                                    "JIT: top-level function captures value '{}' defined later in source order",
-                                    cap.mono_ty_str
-                                ),
-                                "Phase 3d requires source-order init",
-                            ));
-                        }
-                        let val = bcx.use_var(top_vars[target_idx]);
-                        let offset = CAPTURES_OFFSET + 8 * cap_idx as i32;
-                        bcx.ins().store(MemFlags::trusted(), val, closure_ptr, offset);
+            let TopKind::Value(irty) = inst.kind.clone() else {
+                continue;
+            };
+            // SAFETY: AST outlives the JIT compile.
+            let body: &Spanned<Expr> =
+                unsafe { &*(inst.expr_ptr as *const Spanned<Expr>) };
+
+            // Forward-ref check: walk the body, find sibling refs at the
+            // top-level scope (var.resolved.depth == 0). Reject if any refs
+            // either target a later Value (would read an undefined CVar) or
+            // target a Function whose captures include a later Value (would
+            // call into a closure with un-populated captures).
+            let mut refs: HashSet<u32> = HashSet::new();
+            collect_sibling_refs(body, 0, &mut refs);
+            for r in &refs {
+                let r_slot = *r;
+                let Some(&r_idx) = slot_top_idx.get(&r_slot) else {
+                    continue;
+                };
+                match &self.top_level_instances[r_idx].kind {
+                    TopKind::Value(_) if r_slot > inst.slot => {
+                        return Err(Diagnostic::new(
+                            body.1.clone(),
+                            format!(
+                                "JIT: top-level value '{}' references later value at slot {}",
+                                inst.mono_ty_str, r_slot
+                            ),
+                            "value→value forward reference is not yet supported",
+                        ));
                     }
+                    TopKind::Function => {
+                        if let Some(latest) = func_caps_value_max_slot[r_idx] {
+                            if latest > inst.slot {
+                                return Err(Diagnostic::new(
+                                    body.1.clone(),
+                                    format!(
+                                        "JIT: top-level value '{}' calls function whose captures include a later value at slot {}",
+                                        inst.mono_ty_str, latest,
+                                    ),
+                                    "function→later-value works at top level only when the call site is in main, not in a sibling value",
+                                ));
+                            }
+                        }
+                    }
+                    _ => {}
                 }
-                TopKind::Value(irty) => {
-                    // SAFETY: AST outlives the JIT compile.
-                    let body: &Spanned<Expr> =
-                        unsafe { &*(inst.expr_ptr as *const Spanned<Expr>) };
-                    let value_subst = Subst::new();
-                    let env = CompileEnv {
-                        kind: EnvKind::Main {
-                            top_closures: &top_vars,
-                        },
-                        block_frames: Vec::new(),
-                        subst: &value_subst,
-                    };
-                    let module_ptr = &mut self.module as *mut JITModule;
-                    let funcs_ptr = &self.funcs as *const HashMap<FuncKey, FuncInfo>;
-                    let top_level_ptr =
-                        &self.top_level_instances as *const Vec<TopInstance>;
-                    let node_types_ptr = &self.node_types as *const HashMap<usize, Type>;
-                    let alloc_id = self.alloc_closure_id;
-                    let cc = self.call_conv;
-                    let v = unsafe {
-                        compile_expr(
-                            &mut bcx,
-                            body,
-                            &env,
-                            &mut *module_ptr,
-                            &*funcs_ptr,
-                            &*top_level_ptr,
-                            &*node_types_ptr,
-                            alloc_id,
-                            cc,
-                        )
-                    }?;
-                    let v = coerce_to(&mut bcx, v, *irty, &body.1)?;
-                    bcx.def_var(top_vars[i], v);
+            }
+
+            let value_subst = Subst::new();
+            let env = CompileEnv {
+                kind: EnvKind::Main {
+                    top_closures: &top_vars,
+                },
+                block_frames: Vec::new(),
+                subst: &value_subst,
+            };
+            let module_ptr = &mut self.module as *mut JITModule;
+            let funcs_ptr = &self.funcs as *const HashMap<FuncKey, FuncInfo>;
+            let top_level_ptr = &self.top_level_instances as *const Vec<TopInstance>;
+            let node_types_ptr = &self.node_types as *const HashMap<usize, Type>;
+            let alloc_id = self.alloc_closure_id;
+            let cc = self.call_conv;
+            let v = unsafe {
+                compile_expr(
+                    &mut bcx,
+                    body,
+                    &env,
+                    &mut *module_ptr,
+                    &*funcs_ptr,
+                    &*top_level_ptr,
+                    &*node_types_ptr,
+                    alloc_id,
+                    cc,
+                )
+            }?;
+            let v = coerce_to(&mut bcx, v, irty, &body.1)?;
+            bcx.def_var(top_vars[i], v);
+        }
+
+        // B2: populate Function captures. Every CVar target — value or
+        // function — is now def_var'd, so reads are safe.
+        for &i in &order {
+            let inst = self.top_level_instances[i].clone();
+            if !matches!(inst.kind, TopKind::Function) {
+                continue;
+            }
+            let key: FuncKey = (inst.expr_ptr, inst.mono_ty_str.clone());
+            let info = self.funcs.get(&key).expect("declared").clone();
+            let closure_ptr = bcx.use_var(top_vars[i]);
+            for (cap_idx, cap) in info.captures.iter().enumerate() {
+                if cap.inside.depth != 1 {
+                    return Err(Diagnostic::new(
+                        body_span(ast, inst.expr_ptr),
+                        "JIT: top-level function references root scope",
+                        "Phase 3 rejects List/String/Number/import",
+                    ));
                 }
+                let target_idx = self
+                    .top_level_instances
+                    .iter()
+                    .position(|t| {
+                        t.slot == cap.inside.slot && t.mono_ty_str == cap.mono_ty_str
+                    })
+                    .ok_or_else(|| {
+                        internal(format!(
+                            "missing top-level instance for capture (slot {}, ty {})",
+                            cap.inside.slot, cap.mono_ty_str
+                        ))
+                    })?;
+                let val = bcx.use_var(top_vars[target_idx]);
+                let offset = CAPTURES_OFFSET + 8 * cap_idx as i32;
+                bcx.ins().store(MemFlags::trusted(), val, closure_ptr, offset);
             }
         }
 
@@ -1605,10 +1680,13 @@ struct BlockFrame {
     record_ptr: IrValue,
     /// IR types of each slot, in field-declaration order.
     slot_irtys: Vec<IrType>,
-    /// Number of slots already populated. A use with `slot < populated` reads
-    /// from the record; `slot >= populated` is a forward reference and is
-    /// rejected — JIT evaluates Block bindings strictly in source order.
-    populated: u32,
+    /// Per-slot "has its record cell been stored" bit. Function-literal
+    /// bindings are populated in Phase A (before any value body runs) so
+    /// mutual recursion and function→later-value forward refs both work;
+    /// value bindings flip their bit as they're evaluated in source order.
+    /// A read of an un-populated slot is a forward reference and is
+    /// rejected with a diagnostic.
+    populated: Vec<bool>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -2019,23 +2097,23 @@ fn compile_immediate_block(
     frames.push(BlockFrame {
         record_ptr,
         slot_irtys: slot_irtys.clone(),
-        populated: 0,
+        populated: vec![false; defs.len()],
     });
-    for (i, (_, body)) in defs.iter().enumerate() {
-        let inner_env = CompileEnv {
-            kind: env.kind.clone(),
-            block_frames: frames.clone(),
-            subst: env.subst,
-        };
-        let v = compile_expr(
-            bcx, body, &inner_env, module, funcs, top_level, node_types, alloc_id, cc,
-        )?;
-        let irty = slot_irtys[i];
-        let v = coerce_to(bcx, v, irty, &body.1)?;
-        let offset = 8 * i as i32;
-        bcx.ins().store(MemFlags::trusted(), v, record_ptr, offset);
-        frames.last_mut().unwrap().populated = (i + 1) as u32;
-    }
+
+    compile_block_bindings(
+        bcx,
+        defs,
+        env,
+        &mut frames,
+        module,
+        funcs,
+        top_level,
+        node_types,
+        alloc_id,
+        cc,
+        record_ptr,
+        &slot_irtys,
+    )?;
 
     // Compile body using the populated frame.
     let body_env = CompileEnv {
@@ -2102,22 +2180,83 @@ fn compile_block(
         .map(|(_, t)| ir_type_for(t, span))
         .collect::<Result<_, _>>()?;
 
-    // Compile each binding under an env that exposes the partial record at
-    // depth=0. After each store, bump `populated` so subsequent siblings can
-    // observe the value.
     let mut frames = env.block_frames.clone();
     frames.push(BlockFrame {
         record_ptr,
         slot_irtys: slot_irtys.clone(),
-        populated: 0,
+        populated: vec![false; defs.len()],
     });
+
+    compile_block_bindings(
+        bcx,
+        defs,
+        env,
+        &mut frames,
+        module,
+        funcs,
+        top_level,
+        node_types,
+        alloc_id,
+        cc,
+        record_ptr,
+        &slot_irtys,
+    )?;
+
+    Ok(JVal {
+        val: record_ptr,
+        irty: ir_types::I64,
+    })
+}
+
+/// Compile the bindings of a block (or immediate block) into a record that
+/// has already been allocated and pushed as the innermost `BlockFrame` on
+/// `frames`.
+///
+/// Three logical phases:
+///
+/// 1. **Allocate functions**: every function-literal binding gets its
+///    closure allocated and stored in the slot. `cap.inside.depth == 1`
+///    captures (sibling references) are deferred to be populated lazily;
+///    captures pointing outside the block are filled immediately. Mutual
+///    recursion among sibling functions works because all sibling-function
+///    closures exist before any are populated.
+///
+/// 2. **Evaluate values in source order**: for each non-function binding,
+///    opportunistically populate any deferred capture whose target slot is
+///    now stored, refuse to compile if a sibling-function reference still
+///    has unsatisfied captures (would be silent-wrong otherwise), then
+///    compile the body and store the result.
+///
+/// 3. **Finalize**: one last opportunistic populate pass cleans up captures
+///    that only needed values from the final iteration. Any cap that's
+///    still pending after that is a true cycle and is rejected.
+#[allow(clippy::too_many_arguments)]
+fn compile_block_bindings(
+    bcx: &mut FunctionBuilder,
+    defs: &[Bind],
+    env: &CompileEnv,
+    frames: &mut Vec<BlockFrame>,
+    module: &mut JITModule,
+    funcs: &HashMap<FuncKey, FuncInfo>,
+    top_level: &[TopInstance],
+    node_types: &HashMap<usize, Type>,
+    alloc_id: FuncId,
+    cc: CallConv,
+    record_ptr: IrValue,
+    slot_irtys: &[IrType],
+) -> Result<(), Diagnostic> {
+    // Phase 1: allocate each function literal, deferring sibling captures.
+    let mut pending: Vec<Vec<(usize, BindRef, IrType)>> = vec![Vec::new(); defs.len()];
     for (i, ((_, _), body)) in defs.iter().enumerate() {
+        if !matches!(body.0, Expr::Function(_, _)) {
+            continue;
+        }
         let inner_env = CompileEnv {
             kind: env.kind.clone(),
             block_frames: frames.clone(),
             subst: env.subst,
         };
-        let v = compile_expr(
+        let (closure_ptr, deferred) = materialize_closure_partial(
             bcx,
             body,
             &inner_env,
@@ -2127,17 +2266,224 @@ fn compile_block(
             node_types,
             alloc_id,
             cc,
+            &body.1,
+            /* defer_sibling */ true,
+        )?;
+        pending[i] = deferred;
+        let offset = 8 * i as i32;
+        bcx.ins().store(MemFlags::trusted(), closure_ptr, record_ptr, offset);
+        frames.last_mut().unwrap().populated[i] = true;
+    }
+
+    // Initial fixpoint pass: any cap whose target was already populated
+    // (other sibling functions, or non-sibling scopes) can be filled now.
+    populate_caps_until_stable(
+        bcx, &mut pending, record_ptr, slot_irtys, frames, env, module, funcs, top_level, defs,
+    )?;
+
+    // Phase 2: evaluate non-function bindings in source order, with an
+    // opportunistic capture-populate pass after each.
+    for (i, ((_, _), body)) in defs.iter().enumerate() {
+        if matches!(body.0, Expr::Function(_, _)) {
+            continue;
+        }
+
+        // Reject any reference to a sibling function whose captures haven't
+        // all been satisfied — calling it would read garbage.
+        let mut refs: HashSet<u32> = HashSet::new();
+        collect_sibling_refs(body, 0, &mut refs);
+        for r in &refs {
+            let r_idx = *r as usize;
+            if r_idx < pending.len() && !pending[r_idx].is_empty() {
+                return Err(Diagnostic::new(
+                    body.1.clone(),
+                    format!(
+                        "JIT: '{}' uses sibling function '{}' before all of its captures are bound",
+                        crate::symbol::display(defs[i].0 .0),
+                        crate::symbol::display(defs[r_idx].0 .0),
+                    ),
+                    "function captures a later-defined value transitively reached from this binding",
+                ));
+            }
+        }
+
+        let inner_env = CompileEnv {
+            kind: env.kind.clone(),
+            block_frames: frames.clone(),
+            subst: env.subst,
+        };
+        let v = compile_expr(
+            bcx, body, &inner_env, module, funcs, top_level, node_types, alloc_id, cc,
         )?;
         let irty = slot_irtys[i];
         let v = coerce_to(bcx, v, irty, &body.1)?;
         let offset = 8 * i as i32;
         bcx.ins().store(MemFlags::trusted(), v, record_ptr, offset);
-        frames.last_mut().unwrap().populated = (i + 1) as u32;
+        frames.last_mut().unwrap().populated[i] = true;
+
+        populate_caps_until_stable(
+            bcx,
+            &mut pending,
+            record_ptr,
+            slot_irtys,
+            frames,
+            env,
+            module,
+            funcs,
+            top_level,
+            defs,
+        )?;
     }
-    Ok(JVal {
-        val: record_ptr,
-        irty: ir_types::I64,
-    })
+
+    // Phase 3: nothing should remain pending. If something does, the only
+    // possibility is a cap whose target was never populated — a true cycle
+    // (e.g. `x: f, f: (_) => x`).
+    for (i, p) in pending.iter().enumerate() {
+        if !p.is_empty() {
+            return Err(Diagnostic::new(
+                defs[i].1.1.clone(),
+                format!(
+                    "JIT: cyclic binding — '{}'s captures depend on values that never resolve",
+                    crate::symbol::display(defs[i].0 .0),
+                ),
+                "binding directly or indirectly refers to itself through its captures",
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+/// Loop a single capture-population pass until no further progress is made.
+/// Each pass walks the per-slot pending lists; entries whose target slot is
+/// now populated emit a load+store and are dropped from `pending`.
+#[allow(clippy::too_many_arguments)]
+fn populate_caps_until_stable(
+    bcx: &mut FunctionBuilder,
+    pending: &mut [Vec<(usize, BindRef, IrType)>],
+    record_ptr: IrValue,
+    slot_irtys: &[IrType],
+    frames: &[BlockFrame],
+    env: &CompileEnv,
+    module: &mut JITModule,
+    funcs: &HashMap<FuncKey, FuncInfo>,
+    top_level: &[TopInstance],
+    defs: &[Bind],
+) -> Result<(), Diagnostic> {
+    loop {
+        let mut progress = false;
+        let inner_env = CompileEnv {
+            kind: env.kind.clone(),
+            block_frames: frames.to_vec(),
+            subst: env.subst,
+        };
+        let innermost = frames.last().expect("populate_caps expects at least one block frame");
+        for slot in 0..pending.len() {
+            if pending[slot].is_empty() {
+                continue;
+            }
+            let irty = slot_irtys[slot];
+            let mut closure_ptr: Option<IrValue> = None;
+            let drained: Vec<_> = pending[slot].drain(..).collect();
+            for (cap_idx, outer_bref, cap_irty) in drained {
+                let ready = if outer_bref.depth == 0 {
+                    let t = outer_bref.slot as usize;
+                    t < innermost.populated.len() && innermost.populated[t]
+                } else {
+                    // Non-sibling captures (outer scope) are always available
+                    // by the time Phase 1 finishes.
+                    true
+                };
+                if !ready {
+                    pending[slot].push((cap_idx, outer_bref, cap_irty));
+                    continue;
+                }
+                if closure_ptr.is_none() {
+                    closure_ptr = Some(bcx.ins().load(
+                        irty,
+                        MemFlags::trusted(),
+                        record_ptr,
+                        8 * slot as i32,
+                    ));
+                }
+                let val = load_variable(
+                    bcx,
+                    outer_bref,
+                    None,
+                    &inner_env,
+                    module,
+                    funcs,
+                    top_level,
+                    &defs[slot].1.1,
+                )?;
+                let val = coerce_to(bcx, val, cap_irty, &defs[slot].1.1)?;
+                let offset = CAPTURES_OFFSET + 8 * cap_idx as i32;
+                bcx.ins()
+                    .store(MemFlags::trusted(), val, closure_ptr.unwrap(), offset);
+                progress = true;
+            }
+        }
+        if !progress {
+            break;
+        }
+    }
+    Ok(())
+}
+
+/// Collect sibling slots referenced inside `expr` at scope depth `depth`
+/// (0 == the current block's bindings). Walks through nested function
+/// literals because their captures are populated by `materialize_closure`
+/// when the surrounding expression is evaluated, so the targets of those
+/// captures count as eval-time deps of this expression.
+fn collect_sibling_refs(expr: &Spanned<Expr>, depth: u32, out: &mut HashSet<u32>) {
+    match &expr.0 {
+        Expr::Variable(var) => {
+            if let Some(bref) = var.resolved.get() {
+                if bref.depth == depth {
+                    out.insert(bref.slot);
+                }
+            }
+        }
+        Expr::Function(_, b) => collect_sibling_refs(b, depth + 1, out),
+        Expr::List(items) => {
+            for i in items {
+                collect_sibling_refs(i, depth, out);
+            }
+        }
+        Expr::Block(defs) => {
+            for (_, b) in defs {
+                collect_sibling_refs(b, depth + 1, out);
+            }
+        }
+        Expr::ImmediateBlock(s) => {
+            for (_, b) in &s.definitions {
+                collect_sibling_refs(b, depth + 1, out);
+            }
+            collect_sibling_refs(&s.body, depth + 1, out);
+        }
+        Expr::If { cond, cons, alt } => {
+            collect_sibling_refs(cond, depth, out);
+            collect_sibling_refs(cons, depth, out);
+            collect_sibling_refs(alt, depth, out);
+        }
+        Expr::Binary(_, l, r) => {
+            collect_sibling_refs(l, depth, out);
+            collect_sibling_refs(r, depth, out);
+        }
+        Expr::Unary(_, e) => collect_sibling_refs(e, depth, out),
+        Expr::Call(c, args) => {
+            collect_sibling_refs(c, depth, out);
+            for a in args {
+                collect_sibling_refs(a, depth, out);
+            }
+        }
+        Expr::Access(o, _) => collect_sibling_refs(o, depth, out),
+        Expr::Index(a, i) => {
+            collect_sibling_refs(a, depth, out);
+            collect_sibling_refs(i, depth, out);
+        }
+        Expr::Number(_) | Expr::String(_) | Expr::Null | Expr::Bool(_) => {}
+    }
 }
 
 
@@ -2189,14 +2535,15 @@ fn load_variable(
     if bref.depth < n_blocks {
         let frame_idx = bref.depth as usize;
         let frame = &env.block_frames[frame_idx];
-        if bref.slot >= frame.populated {
+        let slot = bref.slot as usize;
+        if slot >= frame.populated.len() || !frame.populated[slot] {
             return Err(Diagnostic::new(
                 span.clone(),
                 "JIT: forward reference inside block",
-                "Phase 3 evaluates block bindings strictly in source order",
+                "Phase 3 evaluates block value bindings strictly in source order",
             ));
         }
-        let irty = frame.slot_irtys[bref.slot as usize];
+        let irty = frame.slot_irtys[slot];
         let offset = 8 * bref.slot as i32;
         let v = bcx.ins().load(irty, MemFlags::trusted(), frame.record_ptr, offset);
         return Ok(JVal { val: v, irty });
@@ -2294,8 +2641,51 @@ fn materialize_closure(
     cc: CallConv,
     span: &Span,
 ) -> Result<JVal, Diagnostic> {
+    let (closure, deferred) = materialize_closure_partial(
+        bcx,
+        func_expr,
+        env,
+        module,
+        funcs,
+        top_level,
+        node_types,
+        alloc_id,
+        cc,
+        span,
+        /* defer_sibling */ false,
+    )?;
+    debug_assert!(deferred.is_empty(), "non-deferred path must populate everything");
+    Ok(JVal {
+        val: closure,
+        irty: ir_types::I64,
+    })
+}
+
+/// Like `materialize_closure` but with optional deferral of sibling captures.
+///
+/// When `defer_sibling` is true (the block Phase A path), captures with
+/// `cap.inside.depth == 1` — i.e. references to other bindings in the same
+/// block scope — are skipped here and returned in the `Vec` so the block
+/// compiler can populate them later, once the sibling slots have been
+/// stored. Non-sibling captures (outer scopes) are populated immediately.
+///
+/// When `defer_sibling` is false this behaves exactly like the legacy
+/// `materialize_closure`: every capture is populated eagerly.
+#[allow(clippy::too_many_arguments, clippy::type_complexity)]
+fn materialize_closure_partial(
+    bcx: &mut FunctionBuilder,
+    func_expr: &Spanned<Expr>,
+    env: &CompileEnv,
+    module: &mut JITModule,
+    funcs: &HashMap<FuncKey, FuncInfo>,
+    top_level: &[TopInstance],
+    node_types: &HashMap<usize, Type>,
+    alloc_id: FuncId,
+    cc: CallConv,
+    span: &Span,
+    defer_sibling: bool,
+) -> Result<(IrValue, Vec<(usize, BindRef, IrType)>), Diagnostic> {
     let expr_ptr = func_expr as *const _ as usize;
-    // The literal's mono ty in this context = its def ty under env's subst.
     let mono = node_types
         .get(&expr_ptr)
         .cloned()
@@ -2310,7 +2700,6 @@ fn materialize_closure(
         )
     })?;
 
-    // Allocate closure.
     let func_ref = module.declare_func_in_func(info.func_id, bcx.func);
     let fn_addr = bcx.ins().func_addr(ir_types::I64, func_ref);
     let n_caps = bcx.ins().iconst(ir_types::I32, info.captures.len() as i64);
@@ -2318,12 +2707,16 @@ fn materialize_closure(
     let inst = bcx.ins().call(alloc_ref, &[fn_addr, n_caps]);
     let closure = bcx.inst_results(inst)[0];
 
-    // Populate captures from outer env.
+    let mut deferred: Vec<(usize, BindRef, IrType)> = Vec::new();
     for (idx, cap) in info.captures.iter().enumerate() {
         let outer_bref = BindRef {
             depth: cap.inside.depth - 1,
             slot: cap.inside.slot,
         };
+        if defer_sibling && cap.inside.depth == 1 {
+            deferred.push((idx, outer_bref, cap.irty));
+            continue;
+        }
         let val = load_variable(
             bcx,
             outer_bref,
@@ -2340,10 +2733,7 @@ fn materialize_closure(
     }
 
     let _ = cc;
-    Ok(JVal {
-        val: closure,
-        irty: ir_types::I64,
-    })
+    Ok((closure, deferred))
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/tests/jit.rs
+++ b/tests/jit.rs
@@ -333,23 +333,95 @@ fn top_level_record_binding() {
 }
 
 #[test]
-fn forward_value_reference_rejected() {
-    let err = jit_run(
-        "
+fn top_level_function_captures_later_value() {
+    // Phase 3h: a top-level function may capture a top-level value defined
+    // later in source order. Phase B evaluates values first, then populates
+    // function captures, so the closure sees `n=10` by the time `add_n(5)`
+    // is called from main.
+    let src = "
         add_n: (x) => x + n,
         n: 10,
         add_n(5)
+    ";
+    assert_eq!(jit_run(src).unwrap(), 15.0);
+}
+
+#[test]
+fn block_function_captures_later_value() {
+    // Same shape as `top_level_function_captures_later_value` but inside an
+    // immediate block. Block compilation Phase 1 allocates closures with
+    // sibling captures deferred; captures are filled lazily as their
+    // target slots become populated during Phase 2.
+    let src = "
+        outer: () => {
+          add_n: (x) => x + n,
+          n: 10,
+          body: add_n(5)
+        }.body,
+        outer()
+    ";
+    assert_eq!(jit_run(src).unwrap(), 15.0);
+}
+
+#[test]
+fn block_mutual_recursion() {
+    // Two sibling functions capturing each other. Closures alloc'd in
+    // Phase 1 so both captures resolve to valid pointers.
+    let src = "
+        outer: () => {
+          is_even: (n) => if n == 0 then 1 else is_odd(n - 1),
+          is_odd:  (n) => if n == 0 then 0 else is_even(n - 1),
+          body: is_even(10)
+        }.body,
+        outer()
+    ";
+    assert_eq!(jit_run(src).unwrap(), 1.0);
+}
+
+#[test]
+fn top_level_value_forward_reference_rejected() {
+    // Value→value forward reference (one Value reading a later Value)
+    // still requires source order. We now reject it explicitly instead of
+    // silently reading an uninitialized CVar.
+    let err = jit_run(
+        "
+        a: b + 1,
+        b: 5,
+        a
         ",
     )
     .unwrap_err();
     assert!(
-        err.contains("source-order init") || err.contains("defined later"),
+        err.contains("references later value") || err.contains("forward"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn top_level_value_calls_function_with_later_cap_rejected() {
+    // Subtle silent-wrong case: a Value calls a sibling Function whose
+    // captures include a not-yet-evaluated Value. Reject explicitly.
+    let err = jit_run(
+        "
+        v: f(5),
+        n: 10,
+        f: (x) => x + n,
+        v
+        ",
+    )
+    .unwrap_err();
+    assert!(
+        err.contains("calls function whose captures include a later value")
+            || err.contains("forward"),
         "unexpected error: {err}"
     );
 }
 
 #[test]
 fn record_forward_reference_rejected() {
+    // Value→value forward reference inside a block is still rejected.
+    // Function→value would now work; this test specifically pins the
+    // value→value case to keep producing a clean diagnostic.
     let err = jit_run(
         "
         foo: (a) => {y: x + 1, x: a},


### PR DESCRIPTION
## Summary

ROADMAP の Phase 3h「(c) Block 内 forward reference 緩和」と「(g) function 内で後の top-level value への forward reference」を 1 PR にまとめて解消。

## Top-level (g)

`compile_program` の Phase B を 2 段に分割：
- **B1**: Value bindings を source order に評価して `def_var`
- **B2**: Function captures を一括 populate（全 Value 済みなので any-order で可）

旧 Phase B の "function captures value defined later" reject を排除し、B1 入り口で 2 種類の forward ref を **silent-wrong → clean compile error** に格上げ：
- value→value forward ref（CVar 未初期化読みで silent 0 だった）
- value が後方 value を capture する関数を呼ぶ（silent garbage call だった）

## Block (c)

`compile_block` と `compile_immediate_block` の重複を `compile_block_bindings` に統合し、Phase 1/2/3 構造に：

| Phase | 内容 |
|---|---|
| 1 | function literal binding を `materialize_closure_partial(defer_sibling=true)` で alloc。sibling cap (`cap.inside.depth == 1`) は pending に保留、それ以外は即 populate。closure を slot に store して `populated[i] = true` |
| 2 | 非 function binding を source order に評価。各評価の前後で `populate_caps_until_stable` を fixpoint で回し、target が populated な pending cap を充填。評価前に `collect_sibling_refs` で sibling function ref を探し、pending cap が残っていれば clean error |
| 3 | 残った pending cap = 真サイクル（`x: f, f: ...x...`）なので reject |

`BlockFrame.populated: u32`（prefix counter）→ `Vec<bool>`（per-slot flag）。`materialize_closure` は `materialize_closure_partial(false)` の薄いラッパに。

## 新たに動くようになったケース

```
// top-level
add_n: (x) => x + n,
n: 10,
add_n(5)  // 15

// block 内 mutual recursion
{
  is_even: (n) => if n == 0 then 1 else is_odd(n - 1),
  is_odd:  (n) => if n == 0 then 0 else is_even(n - 1),
  body: is_even(10)  // 1
}.body

// block 内 function→later-value
{
  add_n: (x) => x + n,
  n: 10,
  body: add_n(5)  // 15
}.body
```

## なお拒否される（明示的に reject、silent-wrong は解消）

- top-level / block 内の value→value forward ref（`a: b + 1, b: 5`）
- value が後方 value を capture する関数を呼ぶ（`v: f(5), n: 10, f: ...`）

これらは値タグ表現が必要で **Phase 4 (NaN-boxing)** 行き。

## Test plan

- [x] `cargo test --release` — snapshot 24 全 pass
- [x] `cargo test --release --test jit` — JIT smoke 43 全 pass（+4 ケース、1 ケース反転）
  - 反転: `forward_value_reference_rejected` → `top_level_function_captures_later_value`
  - 新規: `block_function_captures_later_value`, `block_mutual_recursion`, `top_level_value_forward_reference_rejected`, `top_level_value_calls_function_with_later_cap_rejected`
- [x] `cargo build --release` — clean
- [x] `mutual recursion` 手動確認：以前は segfault → ok
- [x] tree-walker と JIT の結果一致（手動）

https://claude.ai/code/session_01SSRYYXayUfwRSV1zsu9q3k

---
_Generated by [Claude Code](https://claude.ai/code/session_01SSRYYXayUfwRSV1zsu9q3k)_