### PR TITLE
jit: nested block の sibling lookup を innermost-first にして直す

### DIFF
--- a/src/jit.rs
+++ b/src/jit.rs
@@ -2531,9 +2531,13 @@ fn load_variable(
     // Block frames sit between the innermost lookup point and the underlying
     // function/main env. A `bref.depth=K` peels K layers; if K falls within
     // the block-frame stack, we load from the partial record.
+    //
+    // `block_frames` is pushed-to in scope-entry order, so the innermost
+    // frame is at the back. `bref.depth = 0` is innermost, so it indexes
+    // from the back: `block_frames[n_blocks - 1 - depth]`.
     let n_blocks = env.block_frames.len() as u32;
     if bref.depth < n_blocks {
-        let frame_idx = bref.depth as usize;
+        let frame_idx = (n_blocks - 1 - bref.depth) as usize;
         let frame = &env.block_frames[frame_idx];
         let slot = bref.slot as usize;
         if slot >= frame.populated.len() || !frame.populated[slot] {

--- a/tests/jit.rs
+++ b/tests/jit.rs
@@ -447,6 +447,41 @@ fn polymorphic_multi_instance() {
 }
 
 #[test]
+fn nested_block_reads_outer_sibling() {
+    // Inner block reads a sibling of the outer block. `block_frames`
+    // stacks innermost-last; `bref.depth` is innermost-first, so the
+    // lookup must index from the back.
+    let src = "
+        outer: () => {
+          a: 1,
+          c: {x: a + 1, y: x + 1, out: y}.out,
+          body: c
+        }.body,
+        outer()
+    ";
+    assert_eq!(jit_run(src).unwrap(), 3.0);
+}
+
+#[test]
+fn triple_nested_block_reads_outer_siblings() {
+    // Three block scopes; innermost reads from both immediate-outer and
+    // outermost siblings, exercising depths 1 and 2 of the frame stack.
+    let src = "
+        outer: () => {
+          a: 1,
+          b: {
+            c: a + 10,
+            d: {e: a + c, f: e + 1, out: f}.out,
+            out: d
+          }.out,
+          body: b
+        }.body,
+        outer()
+    ";
+    assert_eq!(jit_run(src).unwrap(), 13.0);
+}
+
+#[test]
 fn list_equality_number() {
     assert_eq!(
         jit_run("if [1, 2, 3] == [1, 2, 3] then 1 else 0").unwrap(),


### PR DESCRIPTION
## Summary

Phase 3h の調査中に見つけた pre-existing bug を畳む小さな PR。

`load_variable` は `block_frames[bref.depth]` で参照していたが、Vec の front は **最も外側** のフレーム。一方 resolver は **innermost = depth 0** として `bref.depth` を発行するので、block が 2 つ以上ネストすると外側のフレームを読んでしまい、誤って forward-reference エラーを出していた。

1 段ブロックでは Vec の長さが 1 なので front == last で偶然動いていたため、これまでのテストはすり抜けていた。

### Fix

```diff
-let frame_idx = bref.depth as usize;
+let frame_idx = (n_blocks - 1 - bref.depth) as usize;
```

レイアウト約束（push 順 = scope-entry 順、innermost が back）をコメントで明示。

### Repro（修正前は forward-reference エラー、修正後 = tree-walker と同じ）

```
{
  a: 1,
  c: {x: a + 1, y: x + 1, out: y}.out,
  body: c
}.body  // 3
```

## Test plan

- [x] `cargo test --release` — snapshot 24 全 pass
- [x] `cargo test --release --test jit` — JIT smoke 45 全 pass（+2 ケース）
  - `nested_block_reads_outer_sibling`（depth 1）
  - `triple_nested_block_reads_outer_siblings`（depth 1 & 2）
- [x] 1 段ブロックの既存テスト全部 regress なし

https://claude.ai/code/session_01SSRYYXayUfwRSV1zsu9q3k

---
_Generated by [Claude Code](https://claude.ai/code/session_01SSRYYXayUfwRSV1zsu9q3k)_