### PR TITLE
feat: 文字列補間 "hello ${name}" を全層対応

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -32,7 +32,7 @@
 - パターンマッチ：`match expr { pat => ... }`
 - `?.` (optional chaining)：`obj?.field?.method()`
 - null との型合流：union or option type
-- 文字列補間：`"hello ${name}"`
+- ✅ 文字列補間：`"hello ${name}"` — done 2026-05-17。`${expr}` 部分は `string` 型必須（typeck で unify、auto-stringify は Phase 4 NaN-boxing 待ち）。lexer は `${` でスキャンを分割して `StrBegin/StrLit/InterpOpen/.../InterpClose/StrEnd` シーケンスを emit、plain string は単一 `Token::Str(s)` のまま。JIT は `spctr_str_concat` で左→右に逐次 concat。
 
 **コスト**：中〜大。パターンマッチは特に大物
 **効果**：実用度が一段上がる

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -61,6 +61,11 @@ pub enum UnaryOp {
 pub enum Expr {
     Number(f64),
     String(Rc<String>),
+    /// String interpolation `"a${b}c"`. Each part is concatenated at
+    /// runtime; `Expr` parts must evaluate to a `string`. Plain strings
+    /// (no `${...}`) keep using the cheaper `String` variant; this is
+    /// only produced when the lexer saw at least one `${`.
+    Interpolation(Vec<InterpPart>),
     Variable(VarRef),
     Null,
     Bool(bool),
@@ -78,6 +83,14 @@ pub enum Expr {
     Call(Box<Spanned<Expr>>, Vec<Spanned<Expr>>),
     Access(Box<Spanned<Expr>>, Spanned<Symbol>),
     Index(Box<Spanned<Expr>>, Box<Spanned<Expr>>),
+}
+
+#[derive(Clone, Debug)]
+pub enum InterpPart {
+    /// Literal text fragment with its source span (used for diagnostics).
+    Literal(Rc<String>, crate::lexer::Span),
+    /// Embedded expression — must evaluate to a `string`.
+    Expr(Spanned<Expr>),
 }
 
 pub type AST = Statement;

--- a/src/interp.rs
+++ b/src/interp.rs
@@ -183,6 +183,28 @@ pub fn interpret(expr: &Spanned<Expr>, env: &Env) -> EvalResult {
     match e {
         Expr::Number(n) => Ok(Value::Number(*n)),
         Expr::String(s) => Ok(Value::String(s.clone())),
+        Expr::Interpolation(parts) => {
+            let mut out = String::new();
+            for p in parts {
+                match p {
+                    crate::ast::InterpPart::Literal(s, _) => out.push_str(s),
+                    crate::ast::InterpPart::Expr(e) => match interpret(e, env)? {
+                        Value::String(s) => out.push_str(&s),
+                        other => {
+                            return Err(Diagnostic::new(
+                                e.1.clone(),
+                                format!(
+                                    "string interpolation expects string, got {}",
+                                    other.type_name()
+                                ),
+                                "type mismatch",
+                            ));
+                        }
+                    },
+                }
+            }
+            Ok(Value::String(Rc::new(out)))
+        }
         Expr::Null => Ok(Value::Null),
         Expr::Bool(b) => Ok(Value::Bool(*b)),
         Expr::Variable(var) => {

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -593,6 +593,29 @@ fn emit_print_value(
     Ok(())
 }
 
+/// Materialize a `[len: u32][_pad: u32][bytes]` buffer for a string literal at
+/// JIT compile time. The buffer is `Box::leak`'d so the compiled IR can embed
+/// its address as an i64 constant; strings are immutable in spctr so sharing
+/// the leaked buffer across runs is safe and the leak is bounded by the
+/// literal count.
+fn emit_string_literal(bcx: &mut FunctionBuilder, s: &str) -> JVal {
+    let bytes = s.as_bytes();
+    let mut buf: Vec<u8> = Vec::with_capacity(8 + bytes.len());
+    buf.extend_from_slice(&(bytes.len() as u32).to_le_bytes());
+    buf.extend_from_slice(&[0u8; 4]);
+    buf.extend_from_slice(bytes);
+    let leaked: &'static [u8] = Box::leak(buf.into_boxed_slice());
+    let ptr = leaked.as_ptr() as i64;
+    JVal {
+        val: bcx.ins().iconst(ir_types::I64, ptr),
+        irty: ir_types::I64,
+    }
+}
+
+fn emit_empty_string(bcx: &mut FunctionBuilder) -> JVal {
+    emit_string_literal(bcx, "")
+}
+
 /// Emit IR that prints a value of static type `ty` to stdout. Uses inline
 /// branches/loops for bools/lists; calls `spctr_num_to_string` for numbers.
 fn emit_display(
@@ -1712,20 +1735,52 @@ fn compile_expr(
             val: bcx.ins().iconst(ir_types::I8, i64::from(*b)),
             irty: ir_types::I8,
         }),
-        Expr::String(s) => {
-            // Build a leaked `[len: u32][_pad: u32][bytes]` buffer at JIT compile
-            // time and embed its address as an i64 constant. Strings are
-            // immutable in spctr, so sharing the leaked buffer across runs is
-            // safe; the leak is bounded by the literal count.
-            let bytes = s.as_bytes();
-            let mut buf: Vec<u8> = Vec::with_capacity(8 + bytes.len());
-            buf.extend_from_slice(&(bytes.len() as u32).to_le_bytes());
-            buf.extend_from_slice(&[0u8; 4]);
-            buf.extend_from_slice(bytes);
-            let leaked: &'static [u8] = Box::leak(buf.into_boxed_slice());
-            let ptr = leaked.as_ptr() as i64;
+        Expr::String(s) => Ok(emit_string_literal(bcx, s)),
+        Expr::Interpolation(parts) => {
+            // Compile each part to a string ptr (I64). Literal parts go
+            // through emit_string_literal; Expr parts must already have
+            // type `string` (typeck enforces this). Concatenate left-to-right
+            // via the runtime helper spctr_str_concat.
+            if parts.is_empty() {
+                return Ok(emit_empty_string(bcx));
+            }
+            let concat_id = match module.declarations().get_name("spctr_str_concat") {
+                Some(cranelift_module::FuncOrDataId::Func(id)) => id,
+                _ => return Err(internal("spctr_str_concat not declared")),
+            };
+            let concat_ref = module.declare_func_in_func(concat_id, bcx.func);
+
+            let mut acc: Option<IrValue> = None;
+            for p in parts {
+                let v = match p {
+                    crate::ast::InterpPart::Literal(s, _) => emit_string_literal(bcx, s).val,
+                    crate::ast::InterpPart::Expr(e) => {
+                        let j = compile_expr(
+                            bcx, e, env, module, funcs, top_level, node_types, alloc_id, cc,
+                        )?;
+                        if j.irty != ir_types::I64 {
+                            return Err(Diagnostic::new(
+                                e.1.clone(),
+                                format!(
+                                    "JIT: interpolation expects string, got IR type {}",
+                                    j.irty
+                                ),
+                                "type mismatch",
+                            ));
+                        }
+                        j.val
+                    }
+                };
+                acc = Some(match acc {
+                    None => v,
+                    Some(prev) => {
+                        let inst = bcx.ins().call(concat_ref, &[prev, v]);
+                        bcx.inst_results(inst)[0]
+                    }
+                });
+            }
             Ok(JVal {
-                val: bcx.ins().iconst(ir_types::I64, ptr),
+                val: acc.expect("non-empty parts handled above"),
                 irty: ir_types::I64,
             })
         }
@@ -2481,6 +2536,13 @@ fn collect_sibling_refs(expr: &Spanned<Expr>, depth: u32, out: &mut HashSet<u32>
         Expr::Index(a, i) => {
             collect_sibling_refs(a, depth, out);
             collect_sibling_refs(i, depth, out);
+        }
+        Expr::Interpolation(parts) => {
+            for p in parts {
+                if let crate::ast::InterpPart::Expr(e) = p {
+                    collect_sibling_refs(e, depth, out);
+                }
+            }
         }
         Expr::Number(_) | Expr::String(_) | Expr::Null | Expr::Bool(_) => {}
     }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -77,45 +77,26 @@ pub enum Token {
     #[regex(r"[0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?", |lex| lex.slice().parse::<f64>().ok())]
     Num(f64),
 
-    #[regex(r#""([^"\\]|\\.)*""#, |lex| {
-        let raw = lex.slice();
-        unescape(&raw[1..raw.len()-1])
-    })]
+    /// Plain string literal `"..."` (no interpolation). The interp-aware
+    /// top-level `lex` function emits this for strings that contain no
+    /// `${...}` regions; otherwise it emits the `StrBegin/StrLit/InterpOpen/
+    /// InterpClose/StrEnd` sequence instead.
     Str(String),
+
+    /// Opening `"` of an interpolated string.
+    StrBegin,
+    /// A literal text fragment between quotes / between an `}` and the next
+    /// `${` or closing `"`. May be empty.
+    StrLit(String),
+    /// `${` — start of an interpolated expression.
+    InterpOpen,
+    /// `}` that closes an interpolated expression.
+    InterpClose,
+    /// Closing `"` of an interpolated string.
+    StrEnd,
 
     #[regex(r"[A-Za-z_][A-Za-z0-9_]*", |lex| lex.slice().to_string())]
     Ident(String),
-}
-
-fn unescape(s: &str) -> Option<String> {
-    let mut out = String::with_capacity(s.len());
-    let mut chars = s.chars();
-    while let Some(c) = chars.next() {
-        if c == '\\' {
-            match chars.next()? {
-                'n' => out.push('\n'),
-                't' => out.push('\t'),
-                'r' => out.push('\r'),
-                '\\' => out.push('\\'),
-                '"' => out.push('"'),
-                '/' => out.push('/'),
-                'b' => out.push('\u{0008}'),
-                'f' => out.push('\u{000C}'),
-                'u' => {
-                    let hex: String = chars.by_ref().take(4).collect();
-                    if hex.len() != 4 {
-                        return None;
-                    }
-                    let code = u32::from_str_radix(&hex, 16).ok()?;
-                    out.push(char::from_u32(code)?);
-                }
-                _ => return None,
-            }
-        } else {
-            out.push(c);
-        }
-    }
-    Some(out)
 }
 
 impl std::fmt::Display for Token {
@@ -153,6 +134,11 @@ impl std::fmt::Display for Token {
             Token::OrOr => write!(f, "||"),
             Token::Num(n) => write!(f, "{}", n),
             Token::Str(s) => write!(f, "\"{}\"", s),
+            Token::StrBegin => write!(f, "\""),
+            Token::StrLit(s) => write!(f, "{}", s),
+            Token::InterpOpen => write!(f, "${{"),
+            Token::InterpClose => write!(f, "}}"),
+            Token::StrEnd => write!(f, "\""),
             Token::Ident(s) => write!(f, "{}", s),
         }
     }
@@ -173,18 +159,232 @@ impl std::fmt::Display for LexError {
     }
 }
 
+/// Lexes `src` into a flat token stream.
+///
+/// String literals are scanned manually so we can recognize `${...}` interp
+/// regions: each interp causes the lexer to flush a `StrLit` fragment, emit
+/// `InterpOpen`, recursively lex the expression inside the braces (with
+/// brace-depth tracking so the matching `}` becomes the interp close), and
+/// then resume string mode. Strings with no `${` collapse to the legacy
+/// single `Token::Str(s)` so existing call sites (e.g. the bracket-string
+/// field access `r["foo"]`) keep their fast path.
 pub fn lex(src: &str) -> Result<Vec<(Token, Span)>, Vec<LexError>> {
-    let mut tokens = Vec::new();
-    let mut errors = Vec::new();
-    for (res, span) in Token::lexer(src).spanned() {
-        match res {
-            Ok(t) => tokens.push((t, span)),
-            Err(_) => errors.push(LexError { span }),
+    let mut state = LexState {
+        src,
+        pos: 0,
+        tokens: Vec::new(),
+        errors: Vec::new(),
+    };
+    state.lex_top(false);
+    if state.errors.is_empty() {
+        Ok(state.tokens)
+    } else {
+        Err(state.errors)
+    }
+}
+
+struct LexState<'a> {
+    src: &'a str,
+    pos: usize,
+    tokens: Vec<(Token, Span)>,
+    errors: Vec<LexError>,
+}
+
+impl<'a> LexState<'a> {
+    /// Lex tokens until end-of-input (when `inside_interp = false`) or
+    /// until an unmatched `}` at depth zero (when `inside_interp = true`);
+    /// in the interp case the closing `}` is consumed and emitted as
+    /// `Token::InterpClose`, then this returns.
+    fn lex_top(&mut self, inside_interp: bool) {
+        let mut depth: i32 = 0;
+        while self.pos < self.src.len() {
+            let remaining = &self.src[self.pos..];
+            let c = remaining.chars().next().unwrap();
+
+            if c.is_whitespace() {
+                self.pos += c.len_utf8();
+                continue;
+            }
+            if remaining.starts_with("//") {
+                let nl = remaining.find('\n').map(|n| n + 1).unwrap_or(remaining.len());
+                self.pos += nl;
+                continue;
+            }
+            if remaining.starts_with("/*") {
+                if let Some(end) = remaining[2..].find("*/") {
+                    self.pos += end + 4;
+                } else {
+                    self.errors.push(LexError {
+                        span: self.pos..self.src.len(),
+                    });
+                    self.pos = self.src.len();
+                }
+                continue;
+            }
+
+            if c == '"' {
+                self.lex_string();
+                continue;
+            }
+
+            // Brace depth tracking — when inside an interp, the matching
+            // `}` closes us out.
+            if inside_interp && c == '}' && depth == 0 {
+                self.tokens
+                    .push((Token::InterpClose, self.pos..self.pos + 1));
+                self.pos += 1;
+                return;
+            }
+
+            // Defer to logos for one token at a time. Construct a fresh
+            // Lexer for each iteration; this is cheap enough for our
+            // inputs (REPL lines, ≤ 100KB programs).
+            let mut sub_lex = Token::lexer(remaining);
+            match sub_lex.next() {
+                Some(Ok(t)) => {
+                    let s = sub_lex.span();
+                    if matches!(t, Token::LBrace | Token::LParen | Token::LBracket) {
+                        depth += 1;
+                    } else if matches!(t, Token::RBrace | Token::RParen | Token::RBracket) {
+                        depth -= 1;
+                    }
+                    let abs = (s.start + self.pos)..(s.end + self.pos);
+                    self.tokens.push((t, abs));
+                    self.pos += s.end;
+                }
+                Some(Err(_)) => {
+                    let s = sub_lex.span();
+                    let abs = (s.start + self.pos)..(s.end + self.pos);
+                    self.errors.push(LexError { span: abs });
+                    self.pos += s.end.max(1);
+                }
+                None => break,
+            }
         }
     }
-    if errors.is_empty() {
-        Ok(tokens)
-    } else {
-        Err(errors)
+
+    fn lex_string(&mut self) {
+        let start = self.pos;
+        self.pos += 1; // past opening "
+
+        let mut current_lit = String::new();
+        let mut lit_start = self.pos;
+        // Tokens for an interp-shaped string are buffered locally so that
+        // a plain-string fast path can collapse them into a single
+        // `Token::Str(s)` only if no `${` was encountered.
+        let mut buf: Vec<(Token, Span)> = Vec::new();
+        let mut has_interp = false;
+
+        loop {
+            let Some(c) = self.src[self.pos..].chars().next() else {
+                self.errors.push(LexError {
+                    span: start..self.src.len(),
+                });
+                return;
+            };
+
+            if c == '"' {
+                if has_interp {
+                    buf.push((
+                        Token::StrLit(std::mem::take(&mut current_lit)),
+                        lit_start..self.pos,
+                    ));
+                    buf.push((Token::StrEnd, self.pos..self.pos + 1));
+                    self.tokens.push((Token::StrBegin, start..start + 1));
+                    self.tokens.extend(buf);
+                } else {
+                    self.tokens
+                        .push((Token::Str(current_lit), start..self.pos + 1));
+                }
+                self.pos += 1;
+                return;
+            }
+
+            if c == '\\' {
+                let escape_start = self.pos;
+                if self.pos + 1 >= self.src.len() {
+                    self.errors.push(LexError {
+                        span: escape_start..self.src.len(),
+                    });
+                    return;
+                }
+                let Some(next_c) = self.src[self.pos + 1..].chars().next() else {
+                    self.errors.push(LexError {
+                        span: escape_start..self.src.len(),
+                    });
+                    return;
+                };
+                let escaped: char = match next_c {
+                    'n' => '\n',
+                    't' => '\t',
+                    'r' => '\r',
+                    '\\' => '\\',
+                    '"' => '"',
+                    '/' => '/',
+                    'b' => '\u{0008}',
+                    'f' => '\u{000C}',
+                    '$' => '$',
+                    'u' => {
+                        let hex_start = escape_start + 2;
+                        if hex_start + 4 > self.src.len() {
+                            self.errors.push(LexError {
+                                span: escape_start..self.src.len(),
+                            });
+                            return;
+                        }
+                        let hex = &self.src[hex_start..hex_start + 4];
+                        let Ok(code) = u32::from_str_radix(hex, 16) else {
+                            self.errors.push(LexError {
+                                span: escape_start..hex_start + 4,
+                            });
+                            return;
+                        };
+                        let Some(ch) = char::from_u32(code) else {
+                            self.errors.push(LexError {
+                                span: escape_start..hex_start + 4,
+                            });
+                            return;
+                        };
+                        current_lit.push(ch);
+                        self.pos = hex_start + 4;
+                        continue;
+                    }
+                    _ => {
+                        self.errors.push(LexError {
+                            span: escape_start..escape_start + 2,
+                        });
+                        return;
+                    }
+                };
+                current_lit.push(escaped);
+                self.pos += 1 + next_c.len_utf8();
+                continue;
+            }
+
+            if c == '$' && self.src[self.pos + 1..].starts_with('{') {
+                let interp_start = self.pos;
+                has_interp = true;
+                buf.push((
+                    Token::StrLit(std::mem::take(&mut current_lit)),
+                    lit_start..interp_start,
+                ));
+                buf.push((Token::InterpOpen, interp_start..interp_start + 2));
+                self.pos = interp_start + 2;
+
+                // Recursively lex the inner expression. The inner call
+                // pushes tokens (and a final InterpClose) into self.tokens;
+                // we swap them out so they accumulate into `buf` instead.
+                let saved = std::mem::take(&mut self.tokens);
+                self.lex_top(true);
+                let inner = std::mem::replace(&mut self.tokens, saved);
+                buf.extend(inner);
+
+                lit_start = self.pos;
+                continue;
+            }
+
+            current_lit.push(c);
+            self.pos += c.len_utf8();
+        }
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -66,6 +66,32 @@ where
 
         let var = select! { Token::Ident(s) => Expr::Variable(VarRef::new(intern(&s))) };
 
+        // Interpolated string: `StrBegin StrLit (InterpOpen expr InterpClose StrLit)* StrEnd`.
+        // Plain strings flow through `literal` above (their `Token::Str` is
+        // emitted directly by the lexer when no `${` was found).
+        let interp_lit = select! { Token::StrLit(s) => s }
+            .map_with(|s, ex| (s, span_to_range(ex.span())));
+        let interp_string = just(Token::StrBegin)
+            .ignore_then(interp_lit.clone())
+            .then(
+                just(Token::InterpOpen)
+                    .ignore_then(expr.clone())
+                    .then_ignore(just(Token::InterpClose))
+                    .then(interp_lit.clone())
+                    .repeated()
+                    .collect::<Vec<_>>(),
+            )
+            .then_ignore(just(Token::StrEnd))
+            .map(|((first, first_span), rest): ((String, std::ops::Range<usize>), Vec<(Spanned<Expr>, (String, std::ops::Range<usize>))>)| {
+                let mut parts: Vec<InterpPart> = Vec::with_capacity(1 + rest.len() * 2);
+                parts.push(InterpPart::Literal(std::rc::Rc::new(first), first_span));
+                for (e, (lit, span)) in rest {
+                    parts.push(InterpPart::Expr(e));
+                    parts.push(InterpPart::Literal(std::rc::Rc::new(lit), span));
+                }
+                Expr::Interpolation(parts)
+            });
+
         let list = expr
             .clone()
             .separated_by(just(Token::Comma))
@@ -135,7 +161,7 @@ where
             .clone()
             .delimited_by(just(Token::LParen), just(Token::RParen));
 
-        let atom = choice((literal, if_expr, func, list, brace, var))
+        let atom = choice((literal, interp_string, if_expr, func, list, brace, var))
             .map_with(|e, ex| (e, span_to_range(ex.span())))
             .or(paren);
 

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -35,6 +35,14 @@ impl Resolver {
     fn expr(&mut self, expr: &Spanned<Expr>) -> Result<(), Diagnostic> {
         match &expr.0 {
             Expr::Number(_) | Expr::String(_) | Expr::Null | Expr::Bool(_) => Ok(()),
+            Expr::Interpolation(parts) => {
+                for p in parts {
+                    if let InterpPart::Expr(e) = p {
+                        self.expr(e)?;
+                    }
+                }
+                Ok(())
+            }
             Expr::Variable(var) => {
                 for (depth, scope) in self.scopes.iter().rev().enumerate() {
                     if let Some(slot) = scope.get(&var.name) {

--- a/src/typeck.rs
+++ b/src/typeck.rs
@@ -232,6 +232,15 @@ impl Inferer {
         match &expr.0 {
             Expr::Number(_) => Type::Number,
             Expr::String(_) => Type::String,
+            Expr::Interpolation(parts) => {
+                for p in parts {
+                    if let crate::ast::InterpPart::Expr(e) = p {
+                        let t = self.infer(e, env);
+                        self.unify(&t, &Type::String, &e.1);
+                    }
+                }
+                Type::String
+            }
             Expr::Bool(_) => Type::Bool,
             Expr::Null => Type::Null,
             Expr::Variable(var) => match var.resolved.get() {

--- a/tests/jit.rs
+++ b/tests/jit.rs
@@ -463,6 +463,43 @@ fn nested_block_reads_outer_sibling() {
 }
 
 #[test]
+fn string_interpolation_basic() {
+    // jit_run returns a number, so wrap with String.length to check the
+    // concatenated result has the expected length.
+    let src = r#"
+        name: "world",
+        greeting: "hello ${name}!",
+        String.length(greeting)
+    "#;
+    assert_eq!(jit_run(src).unwrap(), 12.0); // "hello world!"
+}
+
+#[test]
+fn string_interpolation_concat_order() {
+    // Pick a return value that disambiguates the concat order: the
+    // "X-Y-X" pattern can only match if parts are concatenated left
+    // to right.
+    let src = r#"
+        a: "X",
+        b: "Y",
+        s: "${a}-${b}-${a}",
+        if s == "X-Y-X" then 1 else 0
+    "#;
+    assert_eq!(jit_run(src).unwrap(), 1.0);
+}
+
+#[test]
+fn string_interpolation_nested() {
+    // Interp expression contains a nested string with its own interp.
+    let src = r#"
+        a: "X",
+        s: "outer ${if a == "X" then "yes ${a}" else "no"} done",
+        if s == "outer yes X done" then 1 else 0
+    "#;
+    assert_eq!(jit_run(src).unwrap(), 1.0);
+}
+
+#[test]
 fn triple_nested_block_reads_outer_siblings() {
     // Three block scopes; innermost reads from both immediate-outer and
     // outermost siblings, exercising depths 1 and 2 of the frame stack.

--- a/tests/snapshots.rs
+++ b/tests/snapshots.rs
@@ -105,6 +105,33 @@ fn string_escapes() {
 }
 
 #[test]
+fn string_interpolation() {
+    assert_snapshot!(
+        run(r#"name: "world", "hello ${name}!""#),
+        @r###""hello world!""###
+    );
+    assert_snapshot!(
+        run(r#"a: "X", b: "Y", "${a}-${b}-${a}""#),
+        @r###""X-Y-X""###
+    );
+    // `\$` escapes a literal dollar sign so `${...}` can be written literally.
+    assert_snapshot!(
+        run(r#""price: \${5}""#),
+        @r###""price: ${5}""###
+    );
+    // Interp expression itself contains a nested string with its own interp.
+    assert_snapshot!(
+        run(r#"a: "X", "outer ${if a == "X" then "yes ${a}" else "no"} done""#),
+        @r###""outer yes X done""###
+    );
+    // Empty literal fragments on either side of an interp.
+    assert_snapshot!(
+        run(r#"a: "X", "${a}""#),
+        @r###""X""###
+    );
+}
+
+#[test]
 fn comments() {
     assert_snapshot!(run("// comment\n1 + 2"), @"3");
     assert_snapshot!(run("/* block */ 1 + 2"), @"3");


### PR DESCRIPTION
## Summary

ROADMAP の (δ) から「文字列補間」を実装：

```spctr
name: "world",
"hello ${name}!"   // "hello world!"
```

`${expr}` 部分の `expr` は **string 型必須**（typeck で unify）。auto-stringify は型変数経由のオーバーロードが必要で **Phase 4 (NaN-boxing)** 待ち。それまでは `${Number.toString(n)}` 等の明示変換を要求。

## 実装ハイライト

| 層 | 変更 |
|---|---|
| **Lexer** | 旧 `Str` regex を取り外し、`"..."` を手動スキャン。`${` を検出すると literal 部分を flush し、`${...}` 内を再帰的に lex（brace depth + ネスト文字列対応）。plain string は引き続き単一 `Token::Str(s)` で fast path 維持 |
| **AST** | 新ノード `Expr::Interpolation(Vec<InterpPart>)`、`InterpPart = Literal \| Expr` |
| **Parser** | `StrBegin StrLit (InterpOpen expr InterpClose StrLit)* StrEnd` を吸う combinator |
| **Resolver / Typeck / Tree-walker** | 各 `Expr` パートを walk、typeck は `unify(part_ty, String)` |
| **JIT** | `emit_string_literal` を helper に切り出して再利用。Expr パートを compile → I64 (string ptr) を要求 → `spctr_str_concat` で左→右 concat |

`\$` を新規エスケープに追加し、リテラルの `${...}` を書きたいケースに対応。

## エッジケース確認

- 普通の文字列はそのまま（パフォーマンス劣化なし）
- 隣接補間 `"${a}${b}"`、先頭・末尾の補間
- ネスト文字列付き補間: `"outer ${if a == "X" then "yes ${a}" else "no"} done"`
- 非 string を補間に入れると typeck エラー `type mismatch: number vs string`

## Test plan

- [x] `cargo test --release` — snapshot 25 全 pass（+1 ケース、複数アサーション）
- [x] `cargo test --release --test jit` — JIT smoke 48 全 pass（+3 ケース）
- [x] tree-walker と JIT の出力一致を手動確認（10+ ケース）
- [x] unterminated string / unterminated interp が lex error
- [x] `\$` エスケープが両層で動作

https://claude.ai/code/session_01SSRYYXayUfwRSV1zsu9q3k

---
_Generated by [Claude Code](https://claude.ai/code/session_01SSRYYXayUfwRSV1zsu9q3k)_