### PR TITLE
interp: TCO ループ化 — tail recursion をスタック消費なしに、64MB hack を 8MB に縮小

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -89,8 +89,8 @@ AST → Cranelift IR 直行で native コード生成。tree-walker は referenc
 
 ### (ζ) 周辺の磨き込み
 
-- 型変数を `α/β/γ` に rename して表示（今は `?1048576` などの生 ID）
-- 64MB stack hack を消す（TCO or iterative trampoline）
+- ✅ 型変数を `α/β/γ` に rename して表示 — done 2026-05-17（PR #45）
+- ✅ 64MB stack hack を **8MB に縮小 + TCO 実装** — done 2026-05-17（PR #51）。`interpret` を loop ベースに書き直し、`Call` / `If` / `ImmediateBlock` の tail-position 遷移は `cur` ポインタ更新 + `continue` で Rust スタックを消費しない。tail-recursive `loop_n(1_000_000, 0)` が 8MB スタックで通る。非 tail 再帰（`count(n) => ... count(n-1) + 1`）は依然として 1 spctr フレーム ≈ 1.5KB の Rust スタックを食うので、完全撤廃には full iterative trampoline が必要（将来課題）。
 - ベンチ充実（より多角的な性能測定）
 - エラーメッセージの polish
 
@@ -105,11 +105,11 @@ AST → Cranelift IR 直行で native コード生成。tree-walker は referenc
 
 parser の precedence 層を増やすたびに rustc が秒単位→分単位で詰まる。**`.boxed()` で各層を型消去** している。新しい precedence 層を追加するときは必ず `.boxed()` を入れること。これを外すと9分ビルドに戻る。
 
-### 64MB stack hack
+### interp スレッドのスタックサイズ
 
-`src/main.rs` で interp スレッドを `thread::Builder::stack_size(64MB)` で起動している。tree-walker の再帰がそのまま Rust の呼び出しスタックを食うため。TCO を入れるか、iterative trampoline 化するまでは必要。
+`src/main.rs` で interp スレッドを `thread::Builder::stack_size(8MB)` で起動している。Linux pthread のデフォルトと同じ。Phase 3h+TCO 実装後は tail-recursive ループは `cur` ポインタ更新だけで進むため Rust スタックを食わず、`loop_n(1_000_000, 0)` 等が安全に通る。残るのは非 tail 再帰（`count(n) => count(n-1) + 1` 系）で、これは 1 spctr 呼び出し ≈ 1.5KB の Rust フレームを積むため 8MB スタックで深さ約 5000 まで。それ以上の非 tail 再帰には full iterative trampoline 化が必要（未着手）。
 
-`.cargo/config.toml` でテスト時の `RUST_MIN_STACK` も上げてある。
+`.cargo/config.toml` でビルド時の `RUST_MIN_STACK = 64MB` を上げてある。これは tree-walker の runtime とは別物で、chumsky parser combinator の型サイズが巨大なため **rustc 自体が** 大きなスタックを要求する。下げると `cargo build` が SIGSEGV する。
 
 ### lasso interner と TypeVar の衝突
 

--- a/src/interp.rs
+++ b/src/interp.rs
@@ -178,7 +178,116 @@ fn make_frame(defs: &[Bind], parent: &Env, with_names: bool) -> Frame {
     }
 }
 
+// Writes to `current_function` below are load-bearing — they keep the
+// `Rc<Spanned<Expr>>` body alive for the `cur` raw pointer — even though no
+// Rust code subsequently reads the Option directly.
+#[allow(unused_assignments, unused_variables)]
 pub fn interpret(expr: &Spanned<Expr>, env: &Env) -> EvalResult {
+    // Tail-call-optimizing loop. Function calls, `if` branches, and
+    // `ImmediateBlock` bodies are all tail-position transitions: instead of
+    // recursing back into `interpret` (which would grow the Rust stack), we
+    // update `cur` to point at the next expression to evaluate and loop.
+    //
+    // Non-tail sub-expressions (Call arguments, Binary operands, List items,
+    // …) are handled by `interpret_value` below, which still recurses
+    // through `interpret` for its children — but Rust stack growth there
+    // is bounded by *expression* depth, not by *call-chain* depth.
+    //
+    // `cur` is a raw pointer so the loop can rebind it across iterations
+    // without fighting the borrow checker. The pointer is always valid:
+    //
+    // - On entry, it points at the caller's `expr`, which is borrowed for
+    //   the entire `interpret` call.
+    // - On a tail `Call`, we move the callee `Value` (which owns the
+    //   `Rc<Spanned<Expr>>` body) into `current_function`, then point `cur`
+    //   at the body inside that Rc. The previous `current_function`'s body
+    //   is dropped only after `cur` has moved off it.
+    // - On a tail `If` / `ImmediateBlock`, `cur` is redirected at a
+    //   sub-expression of the current node, which lives inside the same
+    //   anchor.
+    let mut current_function: Option<Value> = None;
+    let mut current_env: Env = env.clone();
+    let mut cur: *const Spanned<Expr> = expr;
+    loop {
+        // SAFETY: see the comment above — `cur` is anchored either by the
+        // caller's `expr` borrow or by `current_function`'s held Rc.
+        let e: &Spanned<Expr> = unsafe { &*cur };
+        match &e.0 {
+            Expr::Call(callee, args) => {
+                let callee_val = interpret(callee, &current_env)?;
+                let mut arg_vals: Vec<Value> = Vec::with_capacity(args.len());
+                for arg in args {
+                    arg_vals.push(interpret(arg, &current_env)?);
+                }
+                let (next_ptr, next_env) = match &callee_val {
+                    Value::Function(Function::Native {
+                        params,
+                        body,
+                        env: func_env,
+                    }) => {
+                        if params.len() != arg_vals.len() {
+                            return Err(Diagnostic::new(
+                                e.1.clone(),
+                                format!(
+                                    "expected {} arguments, got {}",
+                                    params.len(),
+                                    arg_vals.len()
+                                ),
+                                "argument count mismatch",
+                            ));
+                        }
+                        let binds: Vec<Rc<RefCell<BindState>>> = arg_vals
+                            .into_iter()
+                            .map(|v| Rc::new(RefCell::new(BindState::Done(v))))
+                            .collect();
+                        let frame = Frame {
+                            binds,
+                            names: None,
+                            parent: func_env.clone(),
+                        };
+                        let next_env = Env(Some(Rc::new(frame)));
+                        let next_ptr = body.as_ref() as *const Spanned<Expr>;
+                        (next_ptr, next_env)
+                    }
+                    Value::Function(Function::Foreign(f)) => {
+                        return f(arg_vals, &e.1);
+                    }
+                    other => {
+                        return Err(Diagnostic::new(
+                            e.1.clone(),
+                            format!("cannot call {}", other.type_name()),
+                            "not a function",
+                        ));
+                    }
+                };
+                cur = next_ptr;
+                current_env = next_env;
+                current_function = Some(callee_val);
+            }
+            Expr::If { cond, cons, alt } => {
+                let c = interpret(cond, &current_env)?;
+                cur = if is_truthy(&c) {
+                    cons.as_ref() as *const _
+                } else {
+                    alt.as_ref() as *const _
+                };
+            }
+            Expr::ImmediateBlock(stmt) => {
+                let frame = make_frame(&stmt.definitions, &current_env, false);
+                current_env = Env(Some(Rc::new(frame)));
+                cur = &stmt.body as *const _;
+            }
+            _ => return interpret_value(e, &current_env),
+        }
+    }
+}
+
+/// Evaluate every `Expr` variant *except* the three tail-positionable ones
+/// (`Call`, `If`, `ImmediateBlock`) which are handled directly by the loop
+/// in `interpret`. Child sub-expressions still recurse through `interpret`,
+/// which means they get TCO too — only the *non*-tail sub-evaluations land
+/// here.
+fn interpret_value(expr: &Spanned<Expr>, env: &Env) -> EvalResult {
     let (e, span) = (&expr.0, &expr.1);
     match e {
         Expr::Number(n) => Ok(Value::Number(*n)),
@@ -252,15 +361,6 @@ pub fn interpret(expr: &Spanned<Expr>, env: &Env) -> EvalResult {
             let frame = make_frame(defs, env, true);
             Ok(Value::Block(Rc::new(frame)))
         }
-        Expr::ImmediateBlock(stmt) => interpret_statement(stmt, env),
-        Expr::If { cond, cons, alt } => {
-            let c = interpret(cond, env)?;
-            if is_truthy(&c) {
-                interpret(cons, env)
-            } else {
-                interpret(alt, env)
-            }
-        }
         Expr::Binary(op, l, r) => {
             let lv = interpret(l, env)?;
             match op {
@@ -286,14 +386,6 @@ pub fn interpret(expr: &Spanned<Expr>, env: &Env) -> EvalResult {
             let v = interpret(e, env)?;
             apply_unaryop(*op, v, span)
         }
-        Expr::Call(callee, args) => {
-            let cv = interpret(callee, env)?;
-            let mut argvs = Vec::with_capacity(args.len());
-            for arg in args {
-                argvs.push(interpret(arg, env)?);
-            }
-            call_value(cv, argvs, span)
-        }
         Expr::Access(obj, (name, name_span)) => {
             let ov = interpret(obj, env)?;
             let frame = match ov {
@@ -313,6 +405,10 @@ pub fn interpret(expr: &Spanned<Expr>, env: &Env) -> EvalResult {
             let iv = interpret(idx, env)?;
             apply_index(av, iv, span)
         }
+        // The TCO loop in `interpret` handles these directly.
+        Expr::Call(_, _) | Expr::If { .. } | Expr::ImmediateBlock(_) => unreachable!(
+            "interpret_value should never see tail-positionable Expr variants"
+        ),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,19 @@ use std::fs;
 use std::process::ExitCode;
 use std::thread;
 
-const INTERP_STACK_SIZE: usize = 64 * 1024 * 1024;
+/// Runtime stack size for the interpreter thread.
+///
+/// Tail-recursive code now goes through the TCO loop in `interp::interpret`
+/// without growing the Rust stack at all, so an accumulator-style
+/// `loop(N, acc) => ...` happily reaches 1M+ iterations regardless of this
+/// limit. The remaining stack consumer is *non*-tail recursion (e.g.
+/// `count(n) => if n == 0 then 0 else count(n - 1) + 1`), which still
+/// builds one Rust frame per spctr call. 8 MiB matches the default Linux
+/// pthread stack and comfortably covers `fib(38)` plus non-tail recursion
+/// up to ~5000 levels — well beyond anything the test suite or examples
+/// exercise. A full iterative trampoline (Phase ζ continuation) would
+/// remove the limit entirely.
+const INTERP_STACK_SIZE: usize = 8 * 1024 * 1024;
 
 #[derive(Parser)]
 #[command(name = "spctr")]

--- a/tests/snapshots.rs
+++ b/tests/snapshots.rs
@@ -145,6 +145,32 @@ fn string_interpolation_auto_stringify() {
 }
 
 #[test]
+fn deep_tail_recursion() {
+    // 100k tail-recursive calls. Before TCO this would blow the 64MB stack
+    // hack; now it loops inside `interpret` without growing Rust frames.
+    assert_snapshot!(
+        run("loop_n: (n, acc) => if n == 0 then acc else loop_n(n - 1, acc + 1), loop_n(100000, 0)"),
+        @"100000"
+    );
+}
+
+#[test]
+fn deep_tail_recursion_with_immediate_block() {
+    // Tail position inside an ImmediateBlock body must also TCO (the loop
+    // updates `cur` to point at `stmt.body`).
+    assert_snapshot!(
+        run(r#"
+          step: (n, acc) => {
+            done: n == 0,
+            if done then acc else step(n - 1, acc + 2)
+          },
+          step(50000, 0)
+        "#),
+        @"100000"
+    );
+}
+
+#[test]
 fn comments() {
     assert_snapshot!(run("// comment\n1 + 2"), @"3");
     assert_snapshot!(run("/* block */ 1 + 2"), @"3");


### PR DESCRIPTION
## Summary

ROADMAP の (ζ)「64MB stack hack を消す（TCO or iterative trampoline）」を解決。`interpret` を loop ベースに書き換え、tail-position の遷移は Rust スタックを消費しなくなりました。

## 実装

`interpret` を「TCO ループ + `interpret_value` ヘルパ」の 2 層構造に。

ループ内で扱う tail-positionable variants:
- **`Expr::Call`**: callee/args を評価したあと、Native function なら新フレームを組んで `cur` を body Rc に向け直して `continue`（Rust 再帰なしで関数呼び出しが連鎖）
- **`Expr::If`**: cond を評価して `cur` を `cons` か `alt` の生ポインタに更新
- **`Expr::ImmediateBlock`**: 新フレームを組んで `cur` を `stmt.body` に更新

それ以外は `interpret_value` に委譲（既存ロジックそのまま）。non-tail の sub-expression（BinOp operands, Call args, List items 等）は `interpret_value` 内から `interpret` を再帰呼び出しするので、Rust スタックの伸びは「式の構造的深さ」までで call chain の深さで伸びることはなくなります。

### 安全性

`cur: *const Spanned<Expr>` は生ポインタ。常に以下のどちらかに anchor：
1. 呼び出し元の `expr` 借用
2. `current_function: Option<Value>` が保持する `Function::Native::body` の `Rc<Spanned<Expr>>` ヒープ領域

tail Call では新 `cur` を導出してから古い `current_function` を Drop する順序にしているので、ぶら下がりは発生しません。

## Stack hack の縮小

`INTERP_STACK_SIZE: 64MB → 8MB`（= Linux pthread デフォルト）。

| ケース | 1MB | 8MB | 16MB | 64MB(旧) |
|---|---|---|---|---|
| tail-rec `loop_n(1_000_000, 0)` | ✓ | ✓ | ✓ | ✓ |
| `fib(38)` | ✓ | ✓ | ✓ | ✓ |
| non-tail `count(5000)` | ✗ | ✓ | ✓ | ✓ |
| non-tail `count(10000)` | ✗ | ✗ | ✓ | ✓ |

実用的なプログラムは 8MB で充分。深い非 tail 再帰の完全撤廃には full iterative trampoline 化が必要で、それは将来課題。

ROADMAP の (ζ) と「直近のメモ・注意点」を更新（RUST_MIN_STACK は別物で、chumsky parser combinator の型サイズ起因で rustc 自身が必要、と明文化）。

## Test plan

- [x] `cargo test --release` — snapshot 28 全 pass（+2 ケース）
  - `deep_tail_recursion`(100k loop)
  - `deep_tail_recursion_with_immediate_block`
- [x] `cargo test --release --test jit` — JIT smoke 51 全 pass
- [x] 8MB スタックで tail-rec 100k / 1M / fib(38) を手動確認
- [x] 64MB → 8MB 縮小後も全テスト pass

https://claude.ai/code/session_01SSRYYXayUfwRSV1zsu9q3k

---
_Generated by [Claude Code](https://claude.ai/code/session_01SSRYYXayUfwRSV1zsu9q3k)_