### PR TITLE
bench: 旧 API ベースの interp ベンチを直して TCO / JIT 比較を追加

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -91,7 +91,7 @@ AST → Cranelift IR 直行で native コード生成。tree-walker は referenc
 
 - ✅ 型変数を `α/β/γ` に rename して表示 — done 2026-05-17（PR #45）
 - ✅ 64MB stack hack を **8MB に縮小 + TCO 実装** — done 2026-05-17（PR #51）。`interpret` を loop ベースに書き直し、`Call` / `If` / `ImmediateBlock` の tail-position 遷移は `cur` ポインタ更新 + `continue` で Rust スタックを消費しない。tail-recursive `loop_n(1_000_000, 0)` が 8MB スタックで通る。非 tail 再帰（`count(n) => ... count(n-1) + 1`）は依然として 1 spctr フレーム ≈ 1.5KB の Rust スタックを食うので、完全撤廃には full iterative trampoline が必要（将来課題）。
-- ベンチ充実（より多角的な性能測定）
+- ✅ ベンチ充実 — done 2026-05-17。`benches/interp.rs` を旧 Iterator API から List/String/Number stdlib ベースに書き直し。`bench_tail_recursion`（TCO 効果測定）と `bench_stdlib_reduce`（JIT inline `List.reduce` 計測）を追加。同 fib / tail-rec / reduce ソースを tree-walker / JIT 両方で測定するように対比形式に。pre-compile 用に `jit::compile` 関数を新規公開（ベンチで b.iter 外で 1 回コンパイルしてから繰り返し走らせる、leak を回避）。直近の実測：fib(25) 94x、tail-rec 100k loop 20x、sum_range 10k 4.6x の JIT スピードアップ。
 - エラーメッセージの polish
 
 **コスト**：小〜中

--- a/benches/interp.rs
+++ b/benches/interp.rs
@@ -1,23 +1,82 @@
+//! Benchmarks for tree-walker and Cranelift JIT.
+//!
+//! We focus on:
+//!
+//! - **fib** — classic deep non-tail recursion (call-overhead dominated).
+//! - **tail_recursion** — accumulator-style loop. Before TCO landed this
+//!   required the 64MB stack hack; now both backends loop in O(1) stack.
+//! - **stdlib_reduce** — exercises the inline-compiled `List.reduce`
+//!   helper in the JIT.
+//! - **fizzbuzz** — `List.map` over a range with string interpolation
+//!   (tree-walker only — `jit::run` is numeric-result-only).
+//! - **parse** — front-end only, to track parser changes in isolation.
+//!
+//! For JIT timings we compile once outside `b.iter` and only measure the
+//! actual `Compiled::run`. Compiling inside `iter` would both inflate the
+//! number with codegen cost and leak executable pages every iteration —
+//! `jit::run` is fire-and-forget on purpose.
 use criterion::{criterion_group, criterion_main, Criterion};
-use spctr::{interp, parser, resolver};
+use spctr::{interp, jit, parser, resolver};
 use std::hint::black_box;
 
-fn run_program(src: &str) {
+fn parse_and_resolve(src: &str) -> spctr::ast::Statement {
     let ast = parser::parse(src).expect("parse failed");
     resolver::resolve(&ast, &interp::ROOT_NAMES).expect("resolve failed");
-    let v = interp::run(&ast).expect("interpret failed");
-    black_box(v);
+    ast
 }
 
 fn bench_fib(c: &mut Criterion) {
     let mut group = c.benchmark_group("fib");
     for n in [10u32, 20, 25] {
         let src = format!(
-            "fib: (n) => if n < 2 then n else fib(n-1) + fib(n-2), fib({})",
+            "fib: (n) => if n < 2 then n else fib(n - 1) + fib(n - 2), fib({})",
             n
         );
-        group.bench_function(format!("fib({})", n), |b| {
-            b.iter(|| run_program(&src));
+        let ast = parse_and_resolve(&src);
+        let compiled = jit::compile(&ast).expect("jit compile");
+        group.bench_function(format!("interp/fib({})", n), |b| {
+            b.iter(|| black_box(interp::run(&ast).expect("interp")));
+        });
+        group.bench_function(format!("jit/fib({})", n), |b| {
+            b.iter(|| black_box(compiled.run()));
+        });
+    }
+    group.finish();
+}
+
+fn bench_tail_recursion(c: &mut Criterion) {
+    let mut group = c.benchmark_group("tail_recursion");
+    for n in [1_000u32, 10_000, 100_000] {
+        let src = format!(
+            "loop_n: (n, acc) => if n == 0 then acc else loop_n(n - 1, acc + 1), loop_n({}, 0)",
+            n
+        );
+        let ast = parse_and_resolve(&src);
+        let compiled = jit::compile(&ast).expect("jit compile");
+        group.bench_function(format!("interp/loop({})", n), |b| {
+            b.iter(|| black_box(interp::run(&ast).expect("interp")));
+        });
+        group.bench_function(format!("jit/loop({})", n), |b| {
+            b.iter(|| black_box(compiled.run()));
+        });
+    }
+    group.finish();
+}
+
+fn bench_stdlib_reduce(c: &mut Criterion) {
+    let mut group = c.benchmark_group("stdlib_reduce");
+    for n in [100u32, 1_000, 10_000] {
+        let src = format!(
+            "List.reduce(List.range(0, {}), 0, (acc, x) => acc + x)",
+            n
+        );
+        let ast = parse_and_resolve(&src);
+        let compiled = jit::compile(&ast).expect("jit compile");
+        group.bench_function(format!("interp/sum_range({})", n), |b| {
+            b.iter(|| black_box(interp::run(&ast).expect("interp")));
+        });
+        group.bench_function(format!("jit/sum_range({})", n), |b| {
+            b.iter(|| black_box(compiled.run()));
         });
     }
     group.finish();
@@ -25,23 +84,21 @@ fn bench_fib(c: &mut Criterion) {
 
 fn bench_fizzbuzz(c: &mut Criterion) {
     let mut group = c.benchmark_group("fizzbuzz");
-    for n in [100u32, 1000] {
+    for n in [100u32, 1_000] {
         let src = format!(
             r#"
-range: Iterator.range(0, {}),
-fizzbuzz: (i) => {{
-  is_fizz: i % 3 == 0,
-  is_buzz: i % 5 == 0,
-  fizz: if is_fizz then "fizz" else "",
-  buzz: if is_buzz then "buzz" else "",
-  String.concat(fizz, buzz)
-}},
-range.map((i) => [i, fizzbuzz(i)]).to_list
+fizzbuzz: (i) =>
+  if i % 15 == 0 then "FizzBuzz"
+  else if i % 3 == 0 then "Fizz"
+  else if i % 5 == 0 then "Buzz"
+  else "${{i}}",
+List.map(List.range(0, {}), fizzbuzz)
 "#,
             n
         );
-        group.bench_function(format!("fizzbuzz({})", n), |b| {
-            b.iter(|| run_program(&src));
+        let ast = parse_and_resolve(&src);
+        group.bench_function(format!("interp/fizzbuzz({})", n), |b| {
+            b.iter(|| black_box(interp::run(&ast).expect("interp")));
         });
     }
     group.finish();
@@ -49,13 +106,17 @@ range.map((i) => [i, fizzbuzz(i)]).to_list
 
 fn bench_parse_only(c: &mut Criterion) {
     let src = include_str!("../examples/fizzbuzz.spc");
-    c.bench_function("parse fizzbuzz.spc", |b| {
-        b.iter(|| {
-            let ast = parser::parse(black_box(src)).expect("parse");
-            black_box(ast);
-        });
+    c.bench_function("parse/fizzbuzz.spc", |b| {
+        b.iter(|| black_box(parser::parse(black_box(src)).expect("parse")));
     });
 }
 
-criterion_group!(benches, bench_fib, bench_fizzbuzz, bench_parse_only);
+criterion_group!(
+    benches,
+    bench_fib,
+    bench_tail_recursion,
+    bench_stdlib_reduce,
+    bench_fizzbuzz,
+    bench_parse_only,
+);
 criterion_main!(benches);

--- a/examples/fizzbuzz.spc
+++ b/examples/fizzbuzz.spc
@@ -1,12 +1,9 @@
-range: Iterator.range(0, 9000),
+// FizzBuzz over [0, 100). Returns a list of strings — number-typed slots
+// would force a heterogeneous list, so `i` is interpolated as a string.
+fizzbuzz: (i) =>
+  if i % 15 == 0 then "FizzBuzz"
+  else if i % 3 == 0 then "Fizz"
+  else if i % 5 == 0 then "Buzz"
+  else "${i}",
 
-fizzbuzz: (i) => {
-  is_fizz: i % 3 = 0,
-  is_buzz: i % 5 = 0,
-  fizz: if is_fizz "fizz" else "",
-  buzz: if is_buzz "buzz" else "",
-
-  String.concat(fizz, buzz)
-},
-
-range.map((i) => [i, fizzbuzz(i)]).to_list
+List.map(List.range(0, 100), fizzbuzz)

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -276,7 +276,36 @@ pub fn run_with_display(ast: &Statement) -> Result<(), Diagnostic> {
     run_inner(ast, true).map(|_| ())
 }
 
-fn run_inner(ast: &Statement, display: bool) -> Result<f64, Diagnostic> {
+/// A handle to a compiled spctr program ready to invoke. The module owning
+/// the JITed executable memory is kept alive for as long as the `Compiled`
+/// is alive — drop the handle to release the memory.
+///
+/// Useful for benchmarking (compile once, run many times) and for embedding
+/// where the program will be called repeatedly without re-parsing.
+pub struct Compiled {
+    main_fn: extern "C" fn() -> f64,
+    // SAFETY anchor: `main_fn` is a raw function pointer into the executable
+    // pages owned by `_module`. The module must outlive every call to
+    // `main_fn`, so we hold it here.
+    _module: JITModule,
+}
+
+impl Compiled {
+    /// Invoke the compiled program. Returns the numeric result (or a
+    /// sentinel `0.0` when the program was compiled in display mode).
+    pub fn run(&self) -> f64 {
+        (self.main_fn)()
+    }
+}
+
+/// Compile an AST into a `Compiled` handle without executing it. The
+/// returned handle is independent of the AST and can be invoked
+/// repeatedly. Most users want [`run`] or [`run_with_display`] instead.
+pub fn compile(ast: &Statement) -> Result<Compiled, Diagnostic> {
+    compile_inner(ast, false)
+}
+
+fn compile_inner(ast: &Statement, display: bool) -> Result<Compiled, Diagnostic> {
     let tres = typeck::check(ast, &interp::root_types());
     if let Some(w) = tres.warnings.into_iter().next() {
         return Err(w);
@@ -292,8 +321,21 @@ fn run_inner(ast: &Statement, display: bool) -> Result<f64, Diagnostic> {
         .map_err(|e| internal(format!("finalize: {e}")))?;
     let main_ptr = module.get_finalized_function(main_id);
     let main_fn: extern "C" fn() -> f64 = unsafe { std::mem::transmute(main_ptr) };
-    let result = main_fn();
-    std::mem::forget(module);
+    Ok(Compiled {
+        main_fn,
+        _module: module,
+    })
+}
+
+fn run_inner(ast: &Statement, display: bool) -> Result<f64, Diagnostic> {
+    let compiled = compile_inner(ast, display)?;
+    let result = compiled.run();
+    // Forget the module: spctr programs leak top-level closure allocations
+    // via `Box::leak` and these point into the module's executable pages;
+    // dropping the module would invalidate them. Callers that want to
+    // reclaim memory should use `compile` + `Compiled` and drop the handle
+    // themselves.
+    std::mem::forget(compiled);
     Ok(result)
 }
 


### PR DESCRIPTION
## Summary

`benches/interp.rs` と `examples/fizzbuzz.spc` が **廃止済みの Iterator stdlib**（`Iterator.range`, `.to_list` 等）を参照していて runtime panic / lex error していたので、現行 API に書き直し。同時に TCO と JIT の効果を計測できるようベンチを拡張。

## 変更内容

### examples/fizzbuzz.spc

`List.range` / 文字列補間ベースに書き直し。tree-walker / JIT 両方で同じ出力（FizzBuzz 100 要素）を確認。

### benches/interp.rs

- `bench_fib`: tree-walker と JIT を同じソースで対比
- `bench_tail_recursion`: TCO 効果計測（1k / 10k / 100k loop）
- `bench_stdlib_reduce`: JIT inline `List.reduce` 計測
- `bench_fizzbuzz`: tree-walker のみ（結果が list of strings で `jit::run` は numeric-only）
- `bench_parse_only`: 更新済み example を使う

### `jit::compile` を新規公開

ベンチで b.iter 外で 1 回コンパイルしてからリプレイするための API。旧 `jit::run` は毎回 `mem::forget(module)` で executable ページを leak する設計で、bench で数千イテレーション回すと OS の memory 上限に当たって `"unable to make memory readable+executable"` で panic していた。

新 `Compiled` ハンドルが `JITModule` を所有し、ドロップで開放。`run()` は `extern "C" fn() -> f64` を呼ぶだけ。既存 `jit::run` は内部で `compile_inner + forget` の薄いラッパに整理（API 互換）。

## 実測値（criterion: warm-up 1s / measure 2s / sample 20）

| ベンチ | tree-walker | JIT | 比 |
|---|---|---|---|
| fib(10) | 49 µs | 0.50 µs | 98x |
| fib(20) | 5.3 ms | 57 µs | 93x |
| fib(25) | 59 ms | 0.63 ms | 94x |
| loop(1k) | 296 µs | 12 µs | 25x |
| loop(10k) | 2.7 ms | 127 µs | 21x |
| loop(100k) | 26 ms | 1.3 ms | 20x |
| sum_range(100) | 21 µs | 3.6 µs | 5.8x |
| sum_range(1k) | 171 µs | 40 µs | 4.3x |
| sum_range(10k) | 1.7 ms | 368 µs | 4.6x |

ROADMAP の (ζ) 「ベンチ充実」を完了枠に。

## Test plan

- [x] `cargo test --release` — 全 79 (28 snapshot + 51 JIT smoke) pass
- [x] `cargo bench --bench interp` — 全 13 シナリオ完走（panic / OOM なし）
- [x] `cargo run examples/fizzbuzz.spc` で tree-walker / JIT 両方 OK

https://claude.ai/code/session_01SSRYYXayUfwRSV1zsu9q3k

---
_Generated by [Claude Code](https://claude.ai/code/session_01SSRYYXayUfwRSV1zsu9q3k)_